### PR TITLE
Explicitly handle more type casts

### DIFF
--- a/varfmt/testdata/src/a/a.go
+++ b/varfmt/testdata/src/a/a.go
@@ -76,6 +76,22 @@ func modifiedpassthrough(format string, args ...interface{}) {
 	fmt.Sprintf(format, args...) // want "variable `format` used for fmt.Sprintf format parameter"
 }
 
+// missedpassthrough isn't identified because it takes a slice instead of a variadic.
+// TODO: handle this case in varfmt?
+func missedpassthrough(format string, args []interface{}) {
+	fmt.Sprintf(format, args...) // want "variable `format` used for fmt.Sprintf format parameter"
+}
+
 func complicated(a, b, format string, args ...interface{}) {
 	fmt.Sprintf(format, args...)
+}
+
+// these used to result in warnings from pt(pp(...))
+// run tests with -v and look for 'unhandled'
+func handled(arr []func(...interface{})) {
+	arr[0](v1)                      // *ast.IndexExpr
+	arr[1](interface{}(v3))         // *ast.InterfaceType
+	_ = map[string]interface{}(nil) // *ast.MapType
+	_ = chan int(nil)               // *ast.ChanType
+	_ = struct{}(struct{}{})        // *ast.StructTyp
 }

--- a/varfmt/varfmt.go
+++ b/varfmt/varfmt.go
@@ -83,7 +83,8 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			case *ast.SelectorExpr:
 				obj := selobj(pass.TypesInfo, callfun)
 				checkarg = fmtarg(printers, obj)
-			case *ast.CallExpr, *ast.TypeAssertExpr, *ast.ParenExpr, *ast.FuncLit, *ast.ArrayType:
+			case *ast.CallExpr, *ast.TypeAssertExpr, *ast.ParenExpr, *ast.IndexExpr:
+			case *ast.FuncLit, *ast.ArrayType, *ast.InterfaceType, *ast.MapType, *ast.ChanType, *ast.StructType:
 			default:
 				pt("unhandled callfun "+pp(n.Fun), n.Fun)
 				return
@@ -251,13 +252,13 @@ func typeobj(obj types.Object) bool {
 }
 
 func typeexpr(ti *types.Info, x ast.Expr) bool {
-	pt(pp(x), x)
 	if sel, ok := x.(*ast.SelectorExpr); ok {
 		x = sel.Sel
 	}
 	if id, ok := x.(*ast.Ident); ok {
 		return typeobj(ti.ObjectOf(id))
 	}
+	pt("typeexpr "+pp(x), x)
 	return false
 }
 


### PR DESCRIPTION
Several of these have their own ast types, so must be handled or
ignored. None of them are relevant for format strings, but they
resulted in unhandled warning spews.