### PR TITLE
Add -no-args to calls with more args

### DIFF
--- a/varfmt/testdata/src/a/a.go
+++ b/varfmt/testdata/src/a/a.go
@@ -3,6 +3,7 @@ package a
 import (
 	"a/pkg"
 	"fmt"
+	"os"
 )
 
 var (
@@ -40,6 +41,7 @@ func bad() {
 	fmt.Sprintf(lookup[false])                                        // want "variable `lookup.false.` used for fmt.Sprintf format parameter"
 	fmt.Sprintf(map[bool]string{false: "false", true: "true"}[false]) // want "non-constant expression used for fmt.Sprintf format parameter"
 	complicated(v1, v2, v3)                                           // want "variable `v3` used for complicated format parameter"
+	fmt.Fprintf(os.Stdout, os.Args[0])                                // want "variable `os.Args.0.` used for fmt.Fprintf format parameter"
 }
 
 func goodf(format string, args ...interface{}) {
@@ -62,6 +64,7 @@ func goodf(format string, args ...interface{}) {
 	fmt.Sprintf(lc)
 	fmt.Sprintf(pkg.C)
 	complicated(v1, v2, c3)
+	fmt.Fprintf(os.Stdout, "%s", os.Args[0])
 }
 
 func passthrough(format string, args ...interface{}) {

--- a/varfmt/varfmt.go
+++ b/varfmt/varfmt.go
@@ -22,12 +22,20 @@ accidental use of potentially unvetted strings can result in ugly tokens like
 all uses of variables as format strings, except those that are merely pass-
 throughs in a wrapper of a printf-like function.`
 
+var noArgs bool
+
+func init() {
+	Analyzer.Flags.BoolVar(&noArgs, "no-args", false, "suppress varfmt reports when formatted args are passed")
+	// allow overriding printf flags
+	funcs := printf.Analyzer.Flags.Lookup("funcs")
+	Analyzer.Flags.Var(funcs.Value, funcs.Name, funcs.Usage)
+}
+
 var Analyzer = &analysis.Analyzer{
 	Name:     "varfmt",
 	Doc:      doc,
 	Requires: []*analysis.Analyzer{inspect.Analyzer, printf.Analyzer},
 	Run:      run,
-	Flags:    printf.Analyzer.Flags, // allow overriding printf flags
 }
 
 func run(pass *analysis.Pass) (interface{}, error) {
@@ -91,6 +99,9 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			}
 
 			if checkarg < 0 {
+				return
+			}
+			if noArgs && len(n.Args)-1 > checkarg {
 				return
 			}
 


### PR DESCRIPTION
While calls such as fmt.Printf(nonconst, arg1) are still iffy according
to the opinions of varfmt, this can help isolate whether formatting was
thought about, or accidentally invoked. Pass -no-args to highlight calls
that appear to be the latter by omitting the former.